### PR TITLE
Add Japanese family name generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,7 @@
-<!-- 
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
-
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
-
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-library-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/developing-packages). 
--->
-
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
 
 ## Features
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+Generating Japanese typical family names.
 
 ## Getting started
 
@@ -25,15 +10,11 @@ start using the package.
 
 ## Usage
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder. 
-
 ```dart
-const like = 'sample';
+const sampleName = generateKanjiCombinedFamilyNameText();
+# e.g. '西川'
 ```
 
 ## Additional information
 
-TODO: Tell users more about the package: where to find more information, how to 
-contribute to the package, how to file issues, what response they can expect 
-from the package authors, and more.
+For additional information, please contact to me.

--- a/lib/japanese_family_name_generator.dart
+++ b/lib/japanese_family_name_generator.dart
@@ -1,7 +1,1 @@
 library japanese_family_name_generator;
-
-/// A Calculator.
-class Calculator {
-  /// Returns [value] plus 1.
-  int addOne(int value) => value + 1;
-}

--- a/lib/japanese_family_name_generator.dart
+++ b/lib/japanese_family_name_generator.dart
@@ -1,1 +1,14 @@
 library japanese_family_name_generator;
+
+import 'dart:math';
+
+String generateKanjiCombinedFamilyNameText() => [
+      ['桜', '松', '竹', '梅', '神', '東', '西', '本', '大', '中', '小']
+          ._getRandomSingle(),
+      ['野', '原', '田', '畑', '川', '瀬', '木', '森', '林', '山', '村']
+          ._getRandomSingle(),
+    ].join();
+
+extension StringsExt on List<String> {
+  String _getRandomSingle() => this[Random().nextInt(length)];
+}

--- a/test/japanese_family_name_generator_test.dart
+++ b/test/japanese_family_name_generator_test.dart
@@ -3,10 +3,4 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:japanese_family_name_generator/japanese_family_name_generator.dart';
 
 void main() {
-  test('adds one to input values', () {
-    final calculator = Calculator();
-    expect(calculator.addOne(2), 3);
-    expect(calculator.addOne(-7), -6);
-    expect(calculator.addOne(0), 1);
-  });
 }

--- a/test/japanese_family_name_generator_test.dart
+++ b/test/japanese_family_name_generator_test.dart
@@ -1,6 +1,20 @@
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:japanese_family_name_generator/japanese_family_name_generator.dart';
 
 void main() {
+  group('generateKanjiCombinedFamilyNameText', () {
+    test('lengthIs2', () {
+      expect(generateKanjiCombinedFamilyNameText().length, equals(2));
+    });
+
+    test('1stCharacterIsAdjectiveKanji', () {
+      expect(['桜', '松', '竹', '梅', '神', '東', '西', '本', '大', '中', '小'],
+          contains(generateKanjiCombinedFamilyNameText()[0]));
+    });
+
+    test('2ndCharacterIsLocationKanji', () {
+      expect(['野', '原', '田', '畑', '川', '瀬', '木', '森', '林', '山', '村'],
+          contains(generateKanjiCombinedFamilyNameText()[1]));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Add functions generating Japanese family name, by combining Japanese Subjective Kanji and Location Kanji.

## Sample

```dart
const name = generateKanjiCombinedFamilyNameText()
# 西川
```

### cf.

- `西川`
  - `西`: means `west`
  - `川`: means `river`

