### PR TITLE
fix lack of information for deployment

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: japanese_family_name_generator
 description: A new Flutter package project.
 version: 0.0.1
-homepage:
+homepage: https://github.com/nishikawa-shi/flutter-japanese-family-name-generator
 
 environment:
   sdk: ">=2.16.1 <3.0.0"


### PR DESCRIPTION
## Summary

Add information for `flutter pub publish -n` error at main branch( d1a2500 ).

## Test result

```
ntetz@ntetzMac ~/A/flutter-japanese-family-name-generator (feature/fix_deploy_error)> flutter pub publish -n
Publishing japanese_family_name_generator 0.0.1 to https://pub.dartlang.org:
|-- CHANGELOG.md
|-- LICENSE
|-- README.md
|-- analysis_options.yaml
|-- lib
|   '-- japanese_family_name_generator.dart
|-- pubspec.yaml
'-- test
    '-- japanese_family_name_generator_test.dart

Package has 0 warnings.
The server may enforce additional checks.
```